### PR TITLE
Corrected the Missspell of Gatsby template to Next.js

### DIFF
--- a/dist/includes/data.json
+++ b/dist/includes/data.json
@@ -438,7 +438,7 @@
     "site_section": "Template",
     "url": "https://github.com/Oddstronaut/tailwind-next",
     "url_image": "templates/nextjs-tailwind.png",
-    "title": "Gatsby Starter Template",
+    "title": "Next.js Starter Template",
     "description": "A Next.js starter template using Tailwind CSS",
     "url_author": "https://github.com/Oddstronaut",
     "author": "Taylor Bryant / @Oddstronaut",


### PR DESCRIPTION
Here Next.js Tailwindcss template wrongly labeled as Gatsby this fixes the issue.