### PR TITLE
Update adding-fonts-to-tailwind-css.md

### DIFF
--- a/dist/guides/adding-fonts-to-tailwind-css.md
+++ b/dist/guides/adding-fonts-to-tailwind-css.md
@@ -109,6 +109,7 @@ If you want to retain the existing font stack and just want to put your font int
 
 ```
 /* In your tailwind.config.js */
+const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
   theme: {


### PR DESCRIPTION
By default the defaultTheme is not included in the tailwind.config.js.
This could be confusing for some..